### PR TITLE
Add IRenderer and AbstractRenderer getParent and getRoot

### DIFF
--- a/layout/src/main/java/com/itextpdf/layout/renderer/AbstractRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/AbstractRenderer.java
@@ -617,6 +617,26 @@ public abstract class AbstractRenderer implements IRenderer {
      * {@inheritDoc}
      */
     @Override
+    public IRenderer getParent() {
+        return parent;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IRenderer getRoot() {
+        IRenderer renderer = this;
+        while (renderer.getParent() != null) {
+            renderer = renderer.getParent();
+        }
+        return renderer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void move(float dxRight, float dyUp) {
         occupiedArea.getBBox().moveRight(dxRight);
         occupiedArea.getBBox().moveUp(dyUp);

--- a/layout/src/main/java/com/itextpdf/layout/renderer/AreaBreakRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/AreaBreakRenderer.java
@@ -131,6 +131,22 @@ public class AreaBreakRenderer implements IRenderer {
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IRenderer getParent() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IRenderer getRoot() {
+        return this;
+    }
+
     @Override
     public IPropertyContainer getModelElement() {
         return null;

--- a/layout/src/main/java/com/itextpdf/layout/renderer/IRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/IRenderer.java
@@ -153,4 +153,16 @@ public interface IRenderer extends IPropertyContainer {
      * @return new renderer instance
      */
     IRenderer getNextRenderer();
+
+    /**
+     * Gets the parent renderer or null if this is the root of the hierarchy.
+     * @return parent renderer
+     */
+    IRenderer getParent();
+
+    /**
+     * Gets the root renderer of the hierarchy (itself if this renderer is the root).
+     * @return root renderer
+     */
+    IRenderer getRoot();
 }

--- a/layout/src/test/java/com/itextpdf/layout/AreaBreakTest.java
+++ b/layout/src/test/java/com/itextpdf/layout/AreaBreakTest.java
@@ -9,6 +9,8 @@ import com.itextpdf.kernel.utils.CompareTool;
 import com.itextpdf.layout.element.AreaBreak;
 import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.property.AreaBreakType;
+import com.itextpdf.layout.renderer.DocumentRenderer;
+import com.itextpdf.layout.renderer.IRenderer;
 import com.itextpdf.test.ExtendedITextTest;
 import com.itextpdf.test.annotations.type.IntegrationTest;
 import org.junit.Assert;
@@ -71,6 +73,20 @@ public class AreaBreakTest extends ExtendedITextTest {
         document.close();
 
         Assert.assertNull(new CompareTool().compareByContent(outFileName, cmpFileName, destinationFolder, "diff"));
+    }
+
+    @Test
+    public void pageBreakTest04() throws IOException, InterruptedException {
+        String outFileName = destinationFolder + "pageBreak4.pdf";
+        PdfDocument pdfDocument = new PdfDocument(new PdfWriter(outFileName));
+
+        Document document = new Document(pdfDocument);
+
+        AreaBreak areaBreak = new AreaBreak(AreaBreakType.NEXT_PAGE);
+        document.add(new Paragraph("Hello World!")).add(areaBreak);
+        IRenderer areaBreakRenderer = areaBreak.getRenderer();
+        Assert.assertNull(areaBreakRenderer.getParent());
+        Assert.assertEquals(areaBreakRenderer, areaBreakRenderer.getRoot());
     }
 
     @Test

--- a/layout/src/test/java/com/itextpdf/layout/PreLayoutTest.java
+++ b/layout/src/test/java/com/itextpdf/layout/PreLayoutTest.java
@@ -116,6 +116,23 @@ public class PreLayoutTest extends ExtendedITextTest{
         Assert.assertNull(new CompareTool().compareByContent(outFileName, cmpFileName, destinationFolder, "diff"));
     }
 
+    @Test
+    public void preLayoutTest03() throws IOException, InterruptedException {
+        String outFileName = destinationFolder + "preLayoutTest03.pdf";
+        PdfDocument pdfDoc = new PdfDocument(new PdfWriter(outFileName));
+
+        Document document = new Document(pdfDoc, PageSize.Default, false);
+        document.add(new Paragraph("A"));
+
+        IRenderer documentRenderer = document.getRenderer();
+        IRenderer paragraphRenderer = documentRenderer.getChildRenderers().get(0);
+        IRenderer textRenderer = paragraphRenderer.getChildRenderers().get(0);
+        Assert.assertEquals(documentRenderer, paragraphRenderer.getParent());
+        Assert.assertEquals(documentRenderer, textRenderer.getRoot());
+        Assert.assertNull(documentRenderer.getParent());
+        Assert.assertEquals(documentRenderer, documentRenderer.getRoot());
+    }
+
     static class TwoColumnParagraphRenderer extends ParagraphRenderer {
 
         int oneColumnPage = -1;


### PR DESCRIPTION
Providing getRoot allows clients to get to the DocumentRenderer to access
DocumentRenderer data. This is especially useful if the DocumentRenderer
has been subclassed.
getParent isn't strictly necessary but seems like it should be there given
setParent, getChildRenderers, and getRoot.
AreaBreakRenderer also gets implementations of these 2 methods, though
they aren't useful.