### PR TITLE
Fix CompareTool on Mac and handling of spaces in names

### DIFF
--- a/io/src/main/java/com/itextpdf/io/util/SystemUtil.java
+++ b/io/src/main/java/com/itextpdf/io/util/SystemUtil.java
@@ -45,7 +45,11 @@ package com.itextpdf.io.util;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This file is a helper class for internal usage only.
@@ -75,13 +79,13 @@ public final class SystemUtil {
     }
 
     public static boolean runProcessAndWait(String execPath, String params) throws IOException, InterruptedException {
-        StringTokenizer st = new StringTokenizer(params);
-        String[] cmdArray = new String[st.countTokens() + 1];
-        cmdArray[0] = execPath;
-        for (int i = 1; st.hasMoreTokens(); ++i)
-            cmdArray[i] = st.nextToken();
+        List<String> cmdArray = new ArrayList<String>();
+        cmdArray.add(execPath);
+        Matcher m = Pattern.compile("((?:[^'\\s]|'.+?')+)\\s*").matcher(params);
+        while (m.find())
+            cmdArray.add(m.group(1).replace("'", ""));
 
-        Process p = Runtime.getRuntime().exec(cmdArray);
+        Process p = Runtime.getRuntime().exec(cmdArray.toArray(new String[cmdArray.size()]));
         printProcessOutput(p);
         return p.waitFor() == 0;
     }

--- a/kernel/src/main/java/com/itextpdf/kernel/utils/CompareTool.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/utils/CompareTool.java
@@ -125,8 +125,8 @@ public class CompareTool {
     private static final String undefinedGsPath = "Path to GhostScript is not specified. Please use -DgsExec=<path_to_ghostscript> (e.g. -DgsExec=\"C:/Program Files/gs/gs9.14/bin/gswin32c.exe\")";
     private static final String ignoredAreasPrefix = "ignored_areas_";
 
-    private static final String gsParams = " -dNOPAUSE -dBATCH -sDEVICE=png16m -r150 -sOutputFile=<outputfile> <inputfile>";
-    private static final String compareParams = " \"<image1>\" \"<image2>\" \"<difference>\"";
+    private static final String gsParams = " -dNOPAUSE -dBATCH -sDEVICE=png16m -r150 -sOutputFile='<outputfile>' '<inputfile>'";
+    private static final String compareParams = " '<image1>' '<image2>' '<difference>'";
 
 
     private String gsExec;
@@ -757,9 +757,9 @@ public class CompareTool {
 
     private String compareVisually(String outPath, String differenceImagePrefix, Map<Integer, List<Rectangle>> ignoredAreas, List<Integer> equalPages) throws IOException, InterruptedException {
         if (gsExec == null)
-            return undefinedGsPath;
-        if (!(new File(gsExec).exists())) {
-            return new File(gsExec).getAbsolutePath() + " does not exist";
+            throw new CompareException(undefinedGsPath);
+        if (!(new File(gsExec).canExecute())) {
+            throw new CompareException(new File(gsExec).getAbsolutePath() + " is not an executable program");
         }
         if (!outPath.endsWith("/"))
             outPath = outPath + "/";
@@ -771,9 +771,7 @@ public class CompareTool {
             createIgnoredAreasPdfs(outPath, ignoredAreas);
         }
 
-        String imagesGenerationResult = runGhostScriptImageGeneration(outPath);
-        if (imagesGenerationResult != null)
-            return imagesGenerationResult;
+        runGhostScriptImageGeneration(outPath);
 
         return compareImagesOfPdfs(outPath, differenceImagePrefix, equalPages);
     }
@@ -787,12 +785,14 @@ public class CompareTool {
         }
         int cnt = Math.min(imageFiles.length, cmpImageFiles.length);
         if (cnt < 1) {
-            return "No files for comparing.\nThe result or sample pdf file is not processed by GhostScript.";
+            throw new CompareException("No files for comparing. The result or sample pdf file is not processed by GhostScript.");
         }
         Arrays.sort(imageFiles, new ImageNameComparator());
         Arrays.sort(cmpImageFiles, new ImageNameComparator());
         String differentPagesFail = null;
-        boolean compareExecIsOk = compareExec != null && new File(compareExec).exists();
+        boolean compareExecIsOk = compareExec != null && new File(compareExec).canExecute();
+        if (compareExec != null && !compareExecIsOk)
+            throw new CompareException(new File(compareExec).getAbsolutePath() + " is not an executable program");
         List<Integer> diffPages = new ArrayList<>();
 
         for (int i = 0; i < cnt; i++) {
@@ -808,10 +808,10 @@ public class CompareTool {
                 differentPagesFail = "Page is different!";
                 diffPages.add(i + 1);
                 if (compareExecIsOk) {
-                String currCompareParams = compareParams.replace("<image1>", imageFiles[i].getAbsolutePath())
+                    String currCompareParams = compareParams.replace("<image1>", imageFiles[i].getAbsolutePath())
                             .replace("<image2>", cmpImageFiles[i].getAbsolutePath())
                             .replace("<difference>", outPath + differenceImagePrefix + Integer.toString(i + 1) + ".png");
-                    if (SystemUtil.runProcessAndWait(compareExec, currCompareParams))
+                    if (!SystemUtil.runProcessAndWait(compareExec, currCompareParams))
                         differentPagesFail += "\nPlease, examine " + outPath + differenceImagePrefix + Integer.toString(i + 1) + ".png for more details.";
                 }
                 System.out.println(differentPagesFail);
@@ -909,20 +909,19 @@ public class CompareTool {
      * @throws IOException
      * @throws InterruptedException
      */
-    private String runGhostScriptImageGeneration(String outPath) throws IOException, InterruptedException {
+    private void runGhostScriptImageGeneration(String outPath) throws IOException, InterruptedException {
         if (!FileUtil.directoryExists(outPath)) {
-            return cannotOpenOutputDirectory.replace("<filename>", outPdf);
+            throw new CompareException(cannotOpenOutputDirectory.replace("<filename>", outPdf));
         }
 
         String currGsParams = gsParams.replace("<outputfile>", outPath + cmpImage).replace("<inputfile>", cmpPdf);
         if (!SystemUtil.runProcessAndWait(gsExec, currGsParams)) {
-            return gsFailed.replace("<filename>", cmpPdf);
+            throw new CompareException(gsFailed.replace("<filename>", cmpPdf));
         }
         currGsParams = gsParams.replace("<outputfile>", outPath + outImage).replace("<inputfile>", outPdf);
         if (!SystemUtil.runProcessAndWait(gsExec, currGsParams)) {
-            return gsFailed.replace("<filename>", outPdf);
+            throw new CompareException(gsFailed.replace("<filename>", outPdf));
         }
-        return null;
     }
 
     private void printOutCmpDirectories() {
@@ -2124,5 +2123,11 @@ public class CompareTool {
             return new TrailerPath(cmpDocument, outDocument, (Stack<LocalPathItem>) path.clone());
         }
 
+    }
+
+    public class CompareException extends RuntimeException {
+        public CompareException(String msg) {
+            super(msg);
+        }
     }
 }

--- a/kernel/src/test/java/com/itextpdf/kernel/utils/CompareToolTest.java
+++ b/kernel/src/test/java/com/itextpdf/kernel/utils/CompareToolTest.java
@@ -105,4 +105,19 @@ public class CompareToolTest extends ExtendedITextTest {
         // Comparing the report to the reference one.
         Assert.assertTrue("CompareTool report differs from the reference one", compareTool.compareXmls(sourceFolder + "cmp_report03.xml", destinationFolder + "screenAnnotation.report.xml"));
     }
+
+    @Test
+    // Test space in name
+    public void compareToolErrorReportTest04() throws InterruptedException, IOException, ParserConfigurationException, SAXException {
+        CompareTool compareTool = new CompareTool();
+        compareTool.setCompareByContentErrorsLimit(10);
+        compareTool.setGenerateCompareByContentXmlReport(true);
+        String outPdf = sourceFolder + "simple_pdf.pdf";
+        String cmpPdf = sourceFolder + "cmp_simple_pdf_with_space .pdf";
+        String result = compareTool.compareByContent(outPdf, cmpPdf, destinationFolder, "difference");
+        System.out.println(result);
+        Assert.assertNotNull("CompareTool must return differences found between the files", result);
+        // Comparing the report to the reference one.
+        Assert.assertTrue("CompareTool report differs from the reference one", compareTool.compareXmls(sourceFolder + "cmp_report01.xml", destinationFolder + "simple_pdf.report.xml"));
+    }
 }

--- a/kernel/src/test/resources/com/itextpdf/kernel/utils/CompareToolTest/cmp_simple_pdf_with_space .pdf
+++ b/kernel/src/test/resources/com/itextpdf/kernel/utils/CompareToolTest/cmp_simple_pdf_with_space .pdf
@@ -1,0 +1,1381 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+2 0 obj 
+<<
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+3 0 obj 
+<<
+/Length 11132
+>>
+stream
+q
+BT
+36 806 Td
+ET
+Q
+q
+Q
+q
+2 J
+0 G
+0.5 w
+36 790 261.5 16 re
+S
+0.5 w
+297.5 790 65.38 16 re
+S
+0.5 w
+362.88 790 196.13 16 re
+S
+0.5 w
+36 774 261.5 16 re
+S
+0.5 w
+297.5 774 65.38 16 re
+S
+0.5 w
+362.88 774 196.13 16 re
+S
+0.5 w
+36 758 261.5 16 re
+S
+0.5 w
+297.5 758 65.38 16 re
+S
+0.5 w
+362.88 758 196.13 16 re
+S
+0.5 w
+36 742 261.5 16 re
+S
+0.5 w
+297.5 742 65.38 16 re
+S
+0.5 w
+362.88 742 196.13 16 re
+S
+0.5 w
+36 726 261.5 16 re
+S
+0.5 w
+297.5 726 65.38 16 re
+S
+0.5 w
+362.88 726 196.13 16 re
+S
+0.5 w
+36 710 261.5 16 re
+S
+0.5 w
+297.5 710 65.38 16 re
+S
+0.5 w
+362.88 710 196.13 16 re
+S
+0.5 w
+36 694 261.5 16 re
+S
+0.5 w
+297.5 694 65.38 16 re
+S
+0.5 w
+362.88 694 196.13 16 re
+S
+0.5 w
+36 678 261.5 16 re
+S
+0.5 w
+297.5 678 65.38 16 re
+S
+0.5 w
+362.88 678 196.13 16 re
+S
+0.5 w
+36 662 261.5 16 re
+S
+0.5 w
+297.5 662 65.38 16 re
+S
+0.5 w
+362.88 662 196.13 16 re
+S
+0.5 w
+36 646 261.5 16 re
+S
+0.5 w
+297.5 646 65.38 16 re
+S
+0.5 w
+362.88 646 196.13 16 re
+S
+0.5 w
+36 630 261.5 16 re
+S
+0.5 w
+297.5 630 65.38 16 re
+S
+0.5 w
+362.88 630 196.13 16 re
+S
+0.5 w
+36 614 261.5 16 re
+S
+0.5 w
+297.5 614 65.38 16 re
+S
+0.5 w
+362.88 614 196.13 16 re
+S
+0.5 w
+36 598 261.5 16 re
+S
+0.5 w
+297.5 598 65.38 16 re
+S
+0.5 w
+362.88 598 196.13 16 re
+S
+0.5 w
+36 582 261.5 16 re
+S
+0.5 w
+297.5 582 65.38 16 re
+S
+0.5 w
+362.88 582 196.13 16 re
+S
+0.5 w
+36 566 261.5 16 re
+S
+0.5 w
+297.5 566 65.38 16 re
+S
+0.5 w
+362.88 566 196.13 16 re
+S
+0.5 w
+36 550 261.5 16 re
+S
+0.5 w
+297.5 550 65.38 16 re
+S
+0.5 w
+362.88 550 196.13 16 re
+S
+0.5 w
+36 534 261.5 16 re
+S
+0.5 w
+297.5 534 65.38 16 re
+S
+0.5 w
+362.88 534 196.13 16 re
+S
+0.5 w
+36 518 261.5 16 re
+S
+0.5 w
+297.5 518 65.38 16 re
+S
+0.5 w
+362.88 518 196.13 16 re
+S
+0.5 w
+36 502 261.5 16 re
+S
+0.5 w
+297.5 502 65.38 16 re
+S
+0.5 w
+362.88 502 196.13 16 re
+S
+0.5 w
+36 486 261.5 16 re
+S
+0.5 w
+297.5 486 65.38 16 re
+S
+0.5 w
+362.88 486 196.13 16 re
+S
+0.5 w
+36 470 261.5 16 re
+S
+0.5 w
+297.5 470 65.38 16 re
+S
+0.5 w
+362.88 470 196.13 16 re
+S
+0.5 w
+36 454 261.5 16 re
+S
+0.5 w
+297.5 454 65.38 16 re
+S
+0.5 w
+362.88 454 196.13 16 re
+S
+0.5 w
+36 438 261.5 16 re
+S
+0.5 w
+297.5 438 65.38 16 re
+S
+0.5 w
+362.88 438 196.13 16 re
+S
+0.5 w
+36 422 261.5 16 re
+S
+0.5 w
+297.5 422 65.38 16 re
+S
+0.5 w
+362.88 422 196.13 16 re
+S
+0.5 w
+36 406 261.5 16 re
+S
+0.5 w
+297.5 406 65.38 16 re
+S
+0.5 w
+362.88 406 196.13 16 re
+S
+0.5 w
+36 390 261.5 16 re
+S
+0.5 w
+297.5 390 65.38 16 re
+S
+0.5 w
+362.88 390 196.13 16 re
+S
+0.5 w
+36 374 261.5 16 re
+S
+0.5 w
+297.5 374 65.38 16 re
+S
+0.5 w
+362.88 374 196.13 16 re
+S
+0.5 w
+36 358 261.5 16 re
+S
+0.5 w
+297.5 358 65.38 16 re
+S
+0.5 w
+362.88 358 196.13 16 re
+S
+0.5 w
+36 342 261.5 16 re
+S
+0.5 w
+297.5 342 65.38 16 re
+S
+0.5 w
+362.88 342 196.13 16 re
+S
+0.5 w
+36 326 261.5 16 re
+S
+0.5 w
+297.5 326 65.38 16 re
+S
+0.5 w
+362.88 326 196.13 16 re
+S
+0.5 w
+36 310 261.5 16 re
+S
+0.5 w
+297.5 310 65.38 16 re
+S
+0.5 w
+362.88 310 196.13 16 re
+S
+0.5 w
+36 294 261.5 16 re
+S
+0.5 w
+297.5 294 65.38 16 re
+S
+0.5 w
+362.88 294 196.13 16 re
+S
+0.5 w
+36 278 261.5 16 re
+S
+0.5 w
+297.5 278 65.38 16 re
+S
+0.5 w
+362.88 278 196.13 16 re
+S
+0.5 w
+36 262 261.5 16 re
+S
+0.5 w
+297.5 262 65.38 16 re
+S
+0.5 w
+362.88 262 196.13 16 re
+S
+0.5 w
+36 246 261.5 16 re
+S
+0.5 w
+297.5 246 65.38 16 re
+S
+0.5 w
+362.88 246 196.13 16 re
+S
+0.5 w
+36 230 261.5 16 re
+S
+0.5 w
+297.5 230 65.38 16 re
+S
+0.5 w
+362.88 230 196.13 16 re
+S
+0.5 w
+36 214 261.5 16 re
+S
+0.5 w
+297.5 214 65.38 16 re
+S
+0.5 w
+362.88 214 196.13 16 re
+S
+0.5 w
+36 198 261.5 16 re
+S
+0.5 w
+297.5 198 65.38 16 re
+S
+0.5 w
+362.88 198 196.13 16 re
+S
+0.5 w
+36 182 261.5 16 re
+S
+0.5 w
+297.5 182 65.38 16 re
+S
+0.5 w
+362.88 182 196.13 16 re
+S
+0.5 w
+36 166 261.5 16 re
+S
+0.5 w
+297.5 166 65.38 16 re
+S
+0.5 w
+362.88 166 196.13 16 re
+S
+0.5 w
+36 150 261.5 16 re
+S
+0.5 w
+297.5 150 65.38 16 re
+S
+0.5 w
+362.88 150 196.13 16 re
+S
+0.5 w
+36 134 261.5 16 re
+S
+0.5 w
+297.5 134 65.38 16 re
+S
+0.5 w
+362.88 134 196.13 16 re
+S
+0.5 w
+36 118 261.5 16 re
+S
+0.5 w
+297.5 118 65.38 16 re
+S
+0.5 w
+362.88 118 196.13 16 re
+S
+0.5 w
+36 102 261.5 16 re
+S
+0.5 w
+297.5 102 65.38 16 re
+S
+0.5 w
+362.88 102 196.13 16 re
+S
+0.5 w
+36 86 261.5 16 re
+S
+0.5 w
+297.5 86 65.38 16 re
+S
+0.5 w
+362.88 86 196.13 16 re
+S
+0.5 w
+36 70 261.5 16 re
+S
+0.5 w
+297.5 70 65.38 16 re
+S
+0.5 w
+362.88 70 196.13 16 re
+S
+0.5 w
+36 54 261.5 16 re
+S
+0.5 w
+297.5 54 65.38 16 re
+S
+0.5 w
+362.88 54 196.13 16 re
+S
+0.5 w
+36 38 261.5 16 re
+S
+0.5 w
+297.5 38 65.38 16 re
+S
+0.5 w
+362.88 38 196.13 16 re
+S
+Q
+BT
+1 0 0 1 38 792 Tm
+/F1 12 Tf
+(name)Tj
+ET
+BT
+1 0 0 1 299.5 792 Tm
+/F1 12 Tf
+(abbr)Tj
+ET
+BT
+1 0 0 1 364.88 792 Tm
+/F1 12 Tf
+(capital)Tj
+ET
+BT
+1 0 0 1 38 776 Tm
+/F2 12 Tf
+(ALABAMA)Tj
+ET
+BT
+1 0 0 1 299.5 776 Tm
+/F2 12 Tf
+(AL)Tj
+ET
+BT
+1 0 0 1 364.88 776 Tm
+/F2 12 Tf
+(Montgomery)Tj
+ET
+BT
+1 0 0 1 38 760 Tm
+/F2 12 Tf
+(ALASKA)Tj
+ET
+BT
+1 0 0 1 299.5 760 Tm
+/F2 12 Tf
+(AK)Tj
+ET
+BT
+1 0 0 1 364.88 760 Tm
+/F2 12 Tf
+(Juneau)Tj
+ET
+BT
+1 0 0 1 38 744 Tm
+/F2 12 Tf
+(ARIZONA)Tj
+ET
+BT
+1 0 0 1 299.5 744 Tm
+/F2 12 Tf
+(AZ)Tj
+ET
+BT
+1 0 0 1 364.88 744 Tm
+/F2 12 Tf
+(Phoenix)Tj
+ET
+BT
+1 0 0 1 38 728 Tm
+/F2 12 Tf
+(ARKANSAS)Tj
+ET
+BT
+1 0 0 1 299.5 728 Tm
+/F2 12 Tf
+(AR)Tj
+ET
+BT
+1 0 0 1 364.88 728 Tm
+/F2 12 Tf
+(Little Rock)Tj
+ET
+BT
+1 0 0 1 38 712 Tm
+/F2 12 Tf
+(CALIFORNIA)Tj
+ET
+BT
+1 0 0 1 299.5 712 Tm
+/F2 12 Tf
+(CA)Tj
+ET
+BT
+1 0 0 1 364.88 712 Tm
+/F2 12 Tf
+(Sacramento)Tj
+ET
+BT
+1 0 0 1 38 696 Tm
+/F2 12 Tf
+(COLORADO)Tj
+ET
+BT
+1 0 0 1 299.5 696 Tm
+/F2 12 Tf
+(CO)Tj
+ET
+BT
+1 0 0 1 364.88 696 Tm
+/F2 12 Tf
+(Denver)Tj
+ET
+BT
+1 0 0 1 38 680 Tm
+/F2 12 Tf
+(CONNECTICUT)Tj
+ET
+BT
+1 0 0 1 299.5 680 Tm
+/F2 12 Tf
+(CT)Tj
+ET
+BT
+1 0 0 1 364.88 680 Tm
+/F2 12 Tf
+(Hartford)Tj
+ET
+BT
+1 0 0 1 38 664 Tm
+/F2 12 Tf
+(DELAWARE)Tj
+ET
+BT
+1 0 0 1 299.5 664 Tm
+/F2 12 Tf
+(DE)Tj
+ET
+BT
+1 0 0 1 364.88 664 Tm
+/F2 12 Tf
+(Dover)Tj
+ET
+BT
+1 0 0 1 38 648 Tm
+/F2 12 Tf
+(FLORIDA)Tj
+ET
+BT
+1 0 0 1 299.5 648 Tm
+/F2 12 Tf
+(FL)Tj
+ET
+BT
+1 0 0 1 364.88 648 Tm
+/F2 12 Tf
+(Tallahassee)Tj
+ET
+BT
+1 0 0 1 38 632 Tm
+/F2 12 Tf
+(GEORGIA)Tj
+ET
+BT
+1 0 0 1 299.5 632 Tm
+/F2 12 Tf
+(GA)Tj
+ET
+BT
+1 0 0 1 364.88 632 Tm
+/F2 12 Tf
+(Atlanta)Tj
+ET
+BT
+1 0 0 1 38 616 Tm
+/F2 12 Tf
+(HAWAII)Tj
+ET
+BT
+1 0 0 1 299.5 616 Tm
+/F2 12 Tf
+(HI)Tj
+ET
+BT
+1 0 0 1 364.88 616 Tm
+/F2 12 Tf
+(Honolulu)Tj
+ET
+BT
+1 0 0 1 38 600 Tm
+/F2 12 Tf
+(IDAHO)Tj
+ET
+BT
+1 0 0 1 299.5 600 Tm
+/F2 12 Tf
+(ID)Tj
+ET
+BT
+1 0 0 1 364.88 600 Tm
+/F2 12 Tf
+(Boise)Tj
+ET
+BT
+1 0 0 1 38 584 Tm
+/F2 12 Tf
+(ILLINOIS)Tj
+ET
+BT
+1 0 0 1 299.5 584 Tm
+/F2 12 Tf
+(IL)Tj
+ET
+BT
+1 0 0 1 364.88 584 Tm
+/F2 12 Tf
+(Springfield)Tj
+ET
+BT
+1 0 0 1 38 568 Tm
+/F2 12 Tf
+(INDIANA)Tj
+ET
+BT
+1 0 0 1 299.5 568 Tm
+/F2 12 Tf
+(IN)Tj
+ET
+BT
+1 0 0 1 364.88 568 Tm
+/F2 12 Tf
+(Indianapolis)Tj
+ET
+BT
+1 0 0 1 38 552 Tm
+/F2 12 Tf
+(IOWA)Tj
+ET
+BT
+1 0 0 1 299.5 552 Tm
+/F2 12 Tf
+(IA)Tj
+ET
+BT
+1 0 0 1 364.88 552 Tm
+/F2 12 Tf
+(Des Moines)Tj
+ET
+BT
+1 0 0 1 38 536 Tm
+/F2 12 Tf
+(KANSAS)Tj
+ET
+BT
+1 0 0 1 299.5 536 Tm
+/F2 12 Tf
+(KS)Tj
+ET
+BT
+1 0 0 1 364.88 536 Tm
+/F2 12 Tf
+(Topeka)Tj
+ET
+BT
+1 0 0 1 38 520 Tm
+/F2 12 Tf
+(KENTUCKY)Tj
+ET
+BT
+1 0 0 1 299.5 520 Tm
+/F2 12 Tf
+(KY)Tj
+ET
+BT
+1 0 0 1 364.88 520 Tm
+/F2 12 Tf
+(Frankfort)Tj
+ET
+BT
+1 0 0 1 38 504 Tm
+/F2 12 Tf
+(LOUISIANA)Tj
+ET
+BT
+1 0 0 1 299.5 504 Tm
+/F2 12 Tf
+(LA)Tj
+ET
+BT
+1 0 0 1 364.88 504 Tm
+/F2 12 Tf
+(Baton Rouge)Tj
+ET
+BT
+1 0 0 1 38 488 Tm
+/F2 12 Tf
+(MAINE)Tj
+ET
+BT
+1 0 0 1 299.5 488 Tm
+/F2 12 Tf
+(ME)Tj
+ET
+BT
+1 0 0 1 364.88 488 Tm
+/F2 12 Tf
+(Augusta)Tj
+ET
+BT
+1 0 0 1 38 472 Tm
+/F2 12 Tf
+(MARYLAND)Tj
+ET
+BT
+1 0 0 1 299.5 472 Tm
+/F2 12 Tf
+(MD)Tj
+ET
+BT
+1 0 0 1 364.88 472 Tm
+/F2 12 Tf
+(Annapolis)Tj
+ET
+BT
+1 0 0 1 38 456 Tm
+/F2 12 Tf
+(MASSACHUSETTS)Tj
+ET
+BT
+1 0 0 1 299.5 456 Tm
+/F2 12 Tf
+(MA)Tj
+ET
+BT
+1 0 0 1 364.88 456 Tm
+/F2 12 Tf
+(Boston)Tj
+ET
+BT
+1 0 0 1 38 440 Tm
+/F2 12 Tf
+(MICHIGAN)Tj
+ET
+BT
+1 0 0 1 299.5 440 Tm
+/F2 12 Tf
+(MI)Tj
+ET
+BT
+1 0 0 1 364.88 440 Tm
+/F2 12 Tf
+(Lansing)Tj
+ET
+BT
+1 0 0 1 38 424 Tm
+/F2 12 Tf
+(MINNESOTA)Tj
+ET
+BT
+1 0 0 1 299.5 424 Tm
+/F2 12 Tf
+(MN)Tj
+ET
+BT
+1 0 0 1 364.88 424 Tm
+/F2 12 Tf
+(Saint Paul)Tj
+ET
+BT
+1 0 0 1 38 408 Tm
+/F2 12 Tf
+(MISSISSIPPI)Tj
+ET
+BT
+1 0 0 1 299.5 408 Tm
+/F2 12 Tf
+(MS)Tj
+ET
+BT
+1 0 0 1 364.88 408 Tm
+/F2 12 Tf
+(Jackson)Tj
+ET
+BT
+1 0 0 1 38 392 Tm
+/F2 12 Tf
+(MISSOURI)Tj
+ET
+BT
+1 0 0 1 299.5 392 Tm
+/F2 12 Tf
+(MO)Tj
+ET
+BT
+1 0 0 1 364.88 392 Tm
+/F2 12 Tf
+(Jefferson City)Tj
+ET
+BT
+1 0 0 1 38 376 Tm
+/F2 12 Tf
+(MONTANA)Tj
+ET
+BT
+1 0 0 1 299.5 376 Tm
+/F2 12 Tf
+(MT)Tj
+ET
+BT
+1 0 0 1 364.88 376 Tm
+/F2 12 Tf
+(Helena)Tj
+ET
+BT
+1 0 0 1 38 360 Tm
+/F2 12 Tf
+(NEBRASKA)Tj
+ET
+BT
+1 0 0 1 299.5 360 Tm
+/F2 12 Tf
+(NE)Tj
+ET
+BT
+1 0 0 1 364.88 360 Tm
+/F2 12 Tf
+(Lincoln)Tj
+ET
+BT
+1 0 0 1 38 344 Tm
+/F2 12 Tf
+(NEVADA)Tj
+ET
+BT
+1 0 0 1 299.5 344 Tm
+/F2 12 Tf
+(NV)Tj
+ET
+BT
+1 0 0 1 364.88 344 Tm
+/F2 12 Tf
+(Carson City)Tj
+ET
+BT
+1 0 0 1 38 328 Tm
+/F2 12 Tf
+(NEW HAMPSHIRE)Tj
+ET
+BT
+1 0 0 1 299.5 328 Tm
+/F2 12 Tf
+(NH)Tj
+ET
+BT
+1 0 0 1 364.88 328 Tm
+/F2 12 Tf
+(Concord)Tj
+ET
+BT
+1 0 0 1 38 312 Tm
+/F2 12 Tf
+(NEW JERSEY)Tj
+ET
+BT
+1 0 0 1 299.5 312 Tm
+/F2 12 Tf
+(NJ)Tj
+ET
+BT
+1 0 0 1 364.88 312 Tm
+/F2 12 Tf
+(Trenton)Tj
+ET
+BT
+1 0 0 1 38 296 Tm
+/F2 12 Tf
+(NEW MEXICO)Tj
+ET
+BT
+1 0 0 1 299.5 296 Tm
+/F2 12 Tf
+(NM)Tj
+ET
+BT
+1 0 0 1 364.88 296 Tm
+/F2 12 Tf
+(Santa Fe)Tj
+ET
+BT
+1 0 0 1 38 280 Tm
+/F2 12 Tf
+(NEW YORK)Tj
+ET
+BT
+1 0 0 1 299.5 280 Tm
+/F2 12 Tf
+(NY)Tj
+ET
+BT
+1 0 0 1 364.88 280 Tm
+/F2 12 Tf
+(Albany)Tj
+ET
+BT
+1 0 0 1 38 264 Tm
+/F2 12 Tf
+(NORTH CAROLINA)Tj
+ET
+BT
+1 0 0 1 299.5 264 Tm
+/F2 12 Tf
+(NC)Tj
+ET
+BT
+1 0 0 1 364.88 264 Tm
+/F2 12 Tf
+(Raleigh)Tj
+ET
+BT
+1 0 0 1 38 248 Tm
+/F2 12 Tf
+(NORTH DAKOTA)Tj
+ET
+BT
+1 0 0 1 299.5 248 Tm
+/F2 12 Tf
+(ND)Tj
+ET
+BT
+1 0 0 1 364.88 248 Tm
+/F2 12 Tf
+(Bismarck)Tj
+ET
+BT
+1 0 0 1 38 232 Tm
+/F2 12 Tf
+(OHIO)Tj
+ET
+BT
+1 0 0 1 299.5 232 Tm
+/F2 12 Tf
+(OH)Tj
+ET
+BT
+1 0 0 1 364.88 232 Tm
+/F2 12 Tf
+(Columbus)Tj
+ET
+BT
+1 0 0 1 38 216 Tm
+/F2 12 Tf
+(OKLAHOMA)Tj
+ET
+BT
+1 0 0 1 299.5 216 Tm
+/F2 12 Tf
+(OK)Tj
+ET
+BT
+1 0 0 1 364.88 216 Tm
+/F2 12 Tf
+(Oklahoma City)Tj
+ET
+BT
+1 0 0 1 38 200 Tm
+/F2 12 Tf
+(OREGON)Tj
+ET
+BT
+1 0 0 1 299.5 200 Tm
+/F2 12 Tf
+(OR)Tj
+ET
+BT
+1 0 0 1 364.88 200 Tm
+/F2 12 Tf
+(Salem)Tj
+ET
+BT
+1 0 0 1 38 184 Tm
+/F2 12 Tf
+(PENNSYLVANIA)Tj
+ET
+BT
+1 0 0 1 299.5 184 Tm
+/F2 12 Tf
+(PA)Tj
+ET
+BT
+1 0 0 1 364.88 184 Tm
+/F2 12 Tf
+(Harrisburg)Tj
+ET
+BT
+1 0 0 1 38 168 Tm
+/F2 12 Tf
+(RHODE ISLAND)Tj
+ET
+BT
+1 0 0 1 299.5 168 Tm
+/F2 12 Tf
+(RI)Tj
+ET
+BT
+1 0 0 1 364.88 168 Tm
+/F2 12 Tf
+(Providence)Tj
+ET
+BT
+1 0 0 1 38 152 Tm
+/F2 12 Tf
+(SOUTH CAROLINA)Tj
+ET
+BT
+1 0 0 1 299.5 152 Tm
+/F2 12 Tf
+(SC)Tj
+ET
+BT
+1 0 0 1 364.88 152 Tm
+/F2 12 Tf
+(Columbia)Tj
+ET
+BT
+1 0 0 1 38 136 Tm
+/F2 12 Tf
+(SOUTH DAKOTA)Tj
+ET
+BT
+1 0 0 1 299.5 136 Tm
+/F2 12 Tf
+(SD)Tj
+ET
+BT
+1 0 0 1 364.88 136 Tm
+/F2 12 Tf
+(Pierre)Tj
+ET
+BT
+1 0 0 1 38 120 Tm
+/F2 12 Tf
+(TENNESSEE)Tj
+ET
+BT
+1 0 0 1 299.5 120 Tm
+/F2 12 Tf
+(TN)Tj
+ET
+BT
+1 0 0 1 364.88 120 Tm
+/F2 12 Tf
+(Nashville)Tj
+ET
+BT
+1 0 0 1 38 104 Tm
+/F2 12 Tf
+(TEXAS)Tj
+ET
+BT
+1 0 0 1 299.5 104 Tm
+/F2 12 Tf
+(TX)Tj
+ET
+BT
+1 0 0 1 364.88 104 Tm
+/F2 12 Tf
+(Austin)Tj
+ET
+BT
+1 0 0 1 38 88 Tm
+/F2 12 Tf
+(UTAH)Tj
+ET
+BT
+1 0 0 1 299.5 88 Tm
+/F2 12 Tf
+(UT)Tj
+ET
+BT
+1 0 0 1 364.88 88 Tm
+/F2 12 Tf
+(Salt Lake City)Tj
+ET
+BT
+1 0 0 1 38 72 Tm
+/F2 12 Tf
+(VERMONT)Tj
+ET
+BT
+1 0 0 1 299.5 72 Tm
+/F2 12 Tf
+(VT)Tj
+ET
+BT
+1 0 0 1 364.88 72 Tm
+/F2 12 Tf
+(Montpelier)Tj
+ET
+BT
+1 0 0 1 38 56 Tm
+/F2 12 Tf
+(VIRGINIA)Tj
+ET
+BT
+1 0 0 1 299.5 56 Tm
+/F2 12 Tf
+(VA)Tj
+ET
+BT
+1 0 0 1 364.88 56 Tm
+/F2 12 Tf
+(Richmond)Tj
+ET
+BT
+1 0 0 1 38 40 Tm
+/F2 12 Tf
+(WASHINGTON)Tj
+ET
+BT
+1 0 0 1 299.5 40 Tm
+/F2 12 Tf
+(WA)Tj
+ET
+BT
+1 0 0 1 364.88 40 Tm
+/F2 12 Tf
+(Olympia)Tj
+ET
+
+endstream 
+endobj 
+4 0 obj 
+<<
+/Kids [5 0 R 6 0 R]
+/Count 2
+/Type /Pages
+>>
+endobj 
+5 0 obj 
+<<
+/Parent 4 0 R
+/MediaBox [0 0 595 842]
+/Resources 
+<<
+/Font 
+<<
+/F2 2 0 R
+/F1 1 0 R
+>>
+>>
+/pdftk_PageNum 1
+/Type /Page
+/Contents 3 0 R
+>>
+endobj 
+7 0 obj 
+<<
+/Length 972
+>>
+stream
+q
+BT
+36 806 Td
+0 -64 Td
+ET
+Q
+q
+Q
+q
+2 J
+0 G
+0.5 w
+36 790 261.5 16 re
+S
+0.5 w
+297.5 790 65.38 16 re
+S
+0.5 w
+362.88 790 196.13 16 re
+S
+0.5 w
+36 774 261.5 16 re
+S
+0.5 w
+297.5 774 65.38 16 re
+S
+0.5 w
+362.88 774 196.13 16 re
+S
+0.5 w
+36 758 261.5 16 re
+S
+0.5 w
+297.5 758 65.38 16 re
+S
+0.5 w
+362.88 758 196.13 16 re
+S
+0.5 w
+36 742 261.5 16 re
+S
+0.5 w
+297.5 742 65.38 16 re
+S
+0.5 w
+362.88 742 196.13 16 re
+S
+Q
+BT
+1 0 0 1 38 792 Tm
+/F1 12 Tf
+(name)Tj
+ET
+BT
+1 0 0 1 299.5 792 Tm
+/F1 12 Tf
+(abbr)Tj
+ET
+BT
+1 0 0 1 364.88 792 Tm
+/F1 12 Tf
+(capital)Tj
+ET
+BT
+1 0 0 1 38 776 Tm
+/F2 12 Tf
+(WEST VIRGINIA)Tj
+ET
+BT
+1 0 0 1 299.5 776 Tm
+/F2 12 Tf
+(WV)Tj
+ET
+BT
+1 0 0 1 364.88 776 Tm
+/F2 12 Tf
+(Charleston)Tj
+ET
+BT
+1 0 0 1 38 760 Tm
+/F2 12 Tf
+(WISCONSIN)Tj
+ET
+BT
+1 0 0 1 299.5 760 Tm
+/F2 12 Tf
+(WI)Tj
+ET
+BT
+1 0 0 1 364.88 760 Tm
+/F2 12 Tf
+(Madison)Tj
+ET
+BT
+1 0 0 1 38 744 Tm
+/F2 12 Tf
+(WYOMING)Tj
+ET
+BT
+1 0 0 1 299.5 744 Tm
+/F2 12 Tf
+(WY)Tj
+ET
+BT
+1 0 0 1 364.88 744 Tm
+/F2 12 Tf
+(Cheyenne)Tj
+ET
+
+endstream 
+endobj 
+6 0 obj 
+<<
+/Parent 4 0 R
+/MediaBox [0 0 595 842]
+/Resources 
+<<
+/Font 
+<<
+/F2 2 0 R
+/F1 1 0 R
+>>
+>>
+/pdftk_PageNum 2
+/Type /Page
+/Contents 7 0 R
+>>
+endobj 
+8 0 obj 
+<<
+/Pages 4 0 R
+/Type /Catalog
+>>
+endobj 
+9 0 obj 
+<<
+/Producer (iTextÆ 5.4.6-SNAPSHOT ©2000-2013 iText Group NV \(AGPL-version\))
+/ModDate (D:20140205125255+01'00')
+/CreationDate (D:20140205125255+01'00')
+>>
+endobj xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000119 00000 n 
+0000000218 00000 n 
+0000011406 00000 n 
+0000011471 00000 n 
+0000012654 00000 n 
+0000011628 00000 n 
+0000012811 00000 n 
+0000012862 00000 n 
+trailer
+
+<<
+/Info 9 0 R
+/Root 8 0 R
+/Size 10
+/ID [<fabd3125be3debdbcaffbef5345b88b2> <fabd3125be3debdbcaffbef5345b88b2>]
+>>
+startxref
+13036
+%%EOF


### PR DESCRIPTION
The original Compare parameter string included double-quotes
which were ignored on Windows but caused compare to always
fail on Mac.

Correctly handle files that include spaces by adding single quotes
around filenames in both the gs and compare parameter strings
and then modifying SystemUtil.runProcessAndWait to ignore spaces
within those quotes when tokenizing the parameters.
compareToolErrorReportTest04 tests processing of a filename that
includes a space.

Reverse check of result of running compare in compareImagesOfPdfs:

Compare returns 0 when there is no change, and
SystemUtil.runProcessAndWait returns true when the result is
zero, so the check of the return value should refer to the
differences output when the the return value is false.  You can
see this in the existing compareToolErrorReportTest01 where
running convert on the first page results in differences but the
"Please, examine" message didn't show up before (and does now).

Change failures when executing gs or compare to be exceptions. By
clearly distinguishing between these failures and detecting
differences, it's easier to detect problems like spaces in
filenames.
(I wanted to further distinguish by the result of running compare, but
compare returns 2 whenever the comparison fails, which includes when
the images are of different dimensions. This means that other
compare failures (such as having an extra " in the filename)
aren't easily detected since compare returns 2 in all these cases.)