### PR TITLE
Make ParagraphRenderer easier to subclass

### DIFF
--- a/layout/src/main/java/com/itextpdf/layout/renderer/AbstractRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/AbstractRenderer.java
@@ -1177,7 +1177,7 @@ public abstract class AbstractRenderer implements IRenderer {
         return !renderer.hasProperty(Property.TOP) && !renderer.hasProperty(Property.BOTTOM) && !renderer.hasProperty(Property.LEFT) && !renderer.hasProperty(Property.RIGHT);
     }
 
-    void shrinkOccupiedAreaForAbsolutePosition() {
+    protected void shrinkOccupiedAreaForAbsolutePosition() {
         // In case of absolute positioning and not specified left, right, width values, the parent box is shrunk to fit
         // the children. It does not occupy all the available width if it does not need to.
         if (isAbsolutePosition()) {

--- a/layout/src/main/java/com/itextpdf/layout/renderer/AbstractWidthHandler.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/AbstractWidthHandler.java
@@ -44,7 +44,7 @@ package com.itextpdf.layout.renderer;
 
 import com.itextpdf.layout.minmaxwidth.MinMaxWidth;
 
-abstract class AbstractWidthHandler {
+public abstract class AbstractWidthHandler {
     MinMaxWidth minMaxWidth;
 
     public AbstractWidthHandler(MinMaxWidth minMaxWidth) {

--- a/layout/src/main/java/com/itextpdf/layout/renderer/LineRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/LineRenderer.java
@@ -384,7 +384,7 @@ public class LineRenderer extends AbstractRenderer {
         return getYLine();
     }
 
-    protected void justify(float width) {
+    public void justify(float width) {
         float ratio = (float) this.getPropertyAsFloat(Property.SPACING_RATIO);
         float freeWidth = occupiedArea.getBBox().getX() + width -
                 getLastChildRenderer().getOccupiedArea().getBBox().getX() - getLastChildRenderer().getOccupiedArea().getBBox().getWidth();
@@ -508,7 +508,7 @@ public class LineRenderer extends AbstractRenderer {
         return this;
     }
 
-    protected boolean containsImage() {
+    public boolean containsImage() {
         for (IRenderer renderer : childRenderers) {
             if (renderer instanceof ImageRenderer) {
                 return true;

--- a/layout/src/main/java/com/itextpdf/layout/renderer/MaxMaxWidthHandler.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/MaxMaxWidthHandler.java
@@ -44,7 +44,7 @@ package com.itextpdf.layout.renderer;
 
 import com.itextpdf.layout.minmaxwidth.MinMaxWidth;
 
-class MaxMaxWidthHandler extends AbstractWidthHandler {
+public class MaxMaxWidthHandler extends AbstractWidthHandler {
 
     public MaxMaxWidthHandler(MinMaxWidth minMaxWidth) {
         super(minMaxWidth);

--- a/layout/src/main/java/com/itextpdf/layout/renderer/ParagraphRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/ParagraphRenderer.java
@@ -236,15 +236,15 @@ public class ParagraphRenderer extends BlockRenderer {
                             }
                         }
                         ParagraphRenderer[] split = split();
-                        split[0].lines = lines;
+                        split[0].setLines(lines);
                         for (LineRenderer line : lines) {
-                            split[0].childRenderers.addAll(line.getChildRenderers());
+                            split[0].getChildRenderers().addAll(line.getChildRenderers());
                         }
                         if (processedRenderer != null) {
-                            split[1].childRenderers.addAll(processedRenderer.getChildRenderers());
+                            split[1].getChildRenderers().addAll(processedRenderer.getChildRenderers());
                         }
                         if (result.getOverflowRenderer() != null) {
-                            split[1].childRenderers.addAll(result.getOverflowRenderer().getChildRenderers());
+                            split[1].getChildRenderers().addAll(result.getOverflowRenderer().getChildRenderers());
                         }
                         if (hasProperty(Property.MAX_HEIGHT)) {
                             if (isPositioned) {
@@ -287,9 +287,9 @@ public class ParagraphRenderer extends BlockRenderer {
                                 // Force placement of children we have and do not force placement of the others
                                 if (LayoutResult.PARTIAL == result.getStatus()) {
                                     IRenderer childNotRendered = result.getCauseOfNothing();
-                                    int firstNotRendered = currentRenderer.childRenderers.indexOf(childNotRendered);
-                                    currentRenderer.childRenderers.retainAll(currentRenderer.childRenderers.subList(0, firstNotRendered));
-                                    split[1].childRenderers.removeAll(split[1].childRenderers.subList(0, firstNotRendered));
+                                    int firstNotRendered = currentRenderer.getChildRenderers().indexOf(childNotRendered);
+                                    currentRenderer.getChildRenderers().retainAll(currentRenderer.getChildRenderers().subList(0, firstNotRendered));
+                                    split[1].getChildRenderers().removeAll(split[1].getChildRenderers().subList(0, firstNotRendered));
                                     return new MinMaxWidthLayoutResult(LayoutResult.PARTIAL, occupiedArea, this, split[1]).setMinMaxWidth(minMaxWidth);
                                 } else {
                                     return new MinMaxWidthLayoutResult(LayoutResult.FULL, occupiedArea, null, null, this).setMinMaxWidth(minMaxWidth);
@@ -426,8 +426,10 @@ public class ParagraphRenderer extends BlockRenderer {
     public void move(float dxRight, float dyUp) {
         occupiedArea.getBBox().moveRight(dxRight);
         occupiedArea.getBBox().moveUp(dyUp);
-        for (LineRenderer line : lines) {
-            line.move(dxRight, dyUp);
+        if (lines != null) {
+            for (LineRenderer line : lines) {
+                line.move(dxRight, dyUp);
+            }
         }
     }
 

--- a/layout/src/main/java/com/itextpdf/layout/renderer/ParagraphRenderer.java
+++ b/layout/src/main/java/com/itextpdf/layout/renderer/ParagraphRenderer.java
@@ -487,4 +487,12 @@ public class ParagraphRenderer extends BlockRenderer {
             overflowRenderer.setProperty(Property.FIRST_LINE_INDENT, 0);
         }
     }
+
+    public List<LineRenderer> getLines() {
+        return lines;
+    }
+
+    public void setLines(List<LineRenderer> lines) {
+        this.lines = lines;
+    }
 }


### PR DESCRIPTION
Change access to a few methods and add a few accessors to make it easier to modify ParagraphRenderer in a new package. The use case is wanting to make changes to ParagraphRenderer.layout in a subclass.
The changes to ParagraphRenderer.layout aren't strictly necessary, but they make it possible to copy that code into a subclass and then make only additions.