### PR TITLE
Fix two NPEs

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfName.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfName.java
@@ -995,6 +995,10 @@ public class PdfName extends PdfPrimitiveObject implements Comparable<PdfName> {
     }
 
     protected void generateValue() {
+        if (content == null) {
+            value = "";
+            return;
+        }
         StringBuilder buf = new StringBuilder();
         try {
             for (int k = 0; k < content.length; ++k) {

--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/tagging/PdfStructTreeRoot.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/tagging/PdfStructTreeRoot.java
@@ -259,7 +259,7 @@ public class PdfStructTreeRoot extends PdfObjectWrapper<PdfDictionary> implement
 
     private void flushAllKids(IPdfStructElem elem) {
         for (IPdfStructElem kid : elem.getKids()) {
-            if (kid instanceof PdfStructElem) {
+            if (kid instanceof PdfStructElem && !((PdfStructElem) kid).isFlushed()) {
                 flushAllKids(kid);
                 ((PdfStructElem) kid).flush();
             }


### PR DESCRIPTION
This fixes two separate NPEs that one of my files triggered by simply opening it with a reader and writer and then closing it.

Please note that I don't actually know what the desired behavior for the case fixed in https://github.com/LingMan/itext7/commit/d7de24834f36c0265d2b3277622eeb3579994e48 is. Therefore I've chosen the output to be the same as if content.length was zero.
You could also fix it by adding a NullPointerExcetion clause to the already existing catch block. That would make the code look more concise but be a bit slower. Feel free to change.