### PR TITLE
GIF frames should be of ImageType GIF

### DIFF
--- a/io/src/main/java/com/itextpdf/io/image/GifImageHelper.java
+++ b/io/src/main/java/com/itextpdf/io/image/GifImageHelper.java
@@ -303,7 +303,7 @@ public final class GifImageHelper {
             colorspace[3] = PdfEncodings.convertToString(gif.m_curr_table, null);
             Map<String, Object> ad = new HashMap<>();
             ad.put("ColorSpace", colorspace);
-            RawImageData img = new RawImageData(gif.m_out, ImageType.NONE);
+            RawImageData img = new RawImageData(gif.m_out, ImageType.GIF);
             RawImageHelper.updateRawImageParameters(img, gif.iw, gif.ih, 1, gif.m_bpc, gif.m_out);
             RawImageHelper.updateImageAttributes(img, ad);
             gif.image.addFrame(img);


### PR DESCRIPTION
this way the following code acts as expected:

assertEquals(ImageType.GIF, ImageDataFactory.create(GIF_FILE_AS_BYTE_ARRAY).getOriginalType());

Codepath:
1. com.itextpdf.io.image.ImageDataFactory.createImageInstance(byte[], boolean) uses GifImageHelper.processImage(image, 0); to read first GIF Frame
2. first Frame is returned via image.getFrames().get(0)