### PR TITLE
allow additional x509 extensions to be critical, as discussed in Ticket SUP-2885

### DIFF
--- a/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
+++ b/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
@@ -293,8 +293,14 @@ final class SignUtils {
     static boolean hasUnsupportedCriticalExtension(X509Certificate cert) {
         if (cert.hasUnsupportedCriticalExtension()) {
             for (String oid : cert.getCriticalExtensionOIDs()) {
-                // KEY USAGE and DIGITAL SIGNING is ALLOWED
-                if ("2.5.29.15".equals(oid) && cert.getKeyUsage()[0]) {
+                // KEY USAGE and DIGITAL SIGNING or NONREPUDIATION is ALLOWED
+                if ("2.5.29.15".equals(oid)) {
+                    if(cert.getKeyUsage()[0] || cert.getKeyUsage()[1]) { // allow digSig and nonRepudiation
+                        continue;
+                    }
+                }
+                // BASIC CONSTRAINTS is ALLOWED
+                if ("2.5.29.19".equals(oid)) { // allow basicConstraints, can be checked later
                     continue;
                 }
                 try {


### PR DESCRIPTION
Jon asked me to create this pull request with the changes I had to make to SignUtils.java in order to make certificate validation work for me (i.e. with certificates that - legitimately - declare some x509 extensions as critical, which iText currently does not allow).

Obviously, basicConstraints should be checked at some time (CA=true/false etc.), but that can't be done at this point, as the entire chain is required for that. But simply blocking any extension that is marked critical beats the purpose. 