### PR TITLE
Malformed cross-reference stream fixed

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfResources.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfResources.java
@@ -484,6 +484,8 @@ public class PdfResources extends PdfObjectWrapper<PdfDictionary> {
         PdfDictionary resourceCategory = getPdfObject().getAsDictionary(resType);
         if (resourceCategory == null) {
             getPdfObject().put(resType, resourceCategory = new PdfDictionary());
+        } else {
+          resourceCategory.setModified();
         }
         resourceCategory.put(resName, resource);
         setModified();

--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfXrefTable.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfXrefTable.java
@@ -264,6 +264,7 @@ class PdfXrefTable implements Serializable {
             if (crypto != null)
                 xrefStream.put(PdfName.Encrypt, crypto);
             xrefStream.put(PdfName.Size, new PdfNumber(this.size()));
+	    sections = createSections(document, false);
 
             int offsetSize = getOffsetSize(Math.max(startxref, size()));
             xrefStream.put(PdfName.W, new PdfArray(


### PR DESCRIPTION
When creating files using the stamper-mode of PdfDocument, I found out that many PDFs generated were complained of by the qpdf tool as having erroneous XREF data. Indeed, the XREF dictionary had a discrepancy between /Index and /Size. I fixed it by recreating sections after creating and adding the XREF stream.