### PR TITLE
Fix null pointer in PdfAcroForm

### DIFF
--- a/forms/src/main/java/com/itextpdf/forms/PdfAcroForm.java
+++ b/forms/src/main/java/com/itextpdf/forms/PdfAcroForm.java
@@ -867,6 +867,10 @@ public class PdfAcroForm extends PdfObjectWrapper<PdfDictionary> {
                 continue;
             }
             PdfFormField formField = PdfFormField.makeFormField(field, document);
+            if (formField == null) {
+                logger.warn("Field {} was null", field);
+                continue;
+            }
             PdfString fieldName = formField.getFieldName();
             String name;
             if (fieldName == null) {


### PR DESCRIPTION
With this code:
```java
pdfDocument = new PdfDocument(new PdfReader(inputStream), new PdfWriter(outputStream));
pdfAcroForm = PdfAcroForm.getAcroForm(pdfDocument, true);
```

At https://github.com/itext/itext7/blob/develop/forms/src/main/java/com/itextpdf/forms/PdfAcroForm.java#L869
When field is of type `com.itextpdf.kernel.pdf.PdfNull`
`PdfFormField.makeFormField` returns `null` and causes a `NullPointerException` on line 870
```java
/*869:*/ PdfFormField formField = PdfFormField.makeFormField(field, document);
/*870:*/ PdfString fieldName = formField.getFieldName();
```