### PR TITLE
Process Outlines using explicit hierarchy

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfCatalog.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfCatalog.java
@@ -521,46 +521,6 @@ public class PdfCatalog extends PdfObjectWrapper<PdfDictionary> {
         }
     }
 
-    /**
-     * Get the next outline of the current node in the outline tree by looking for a child or sibling node.
-     * If there is no child or sibling of the current node {@link PdfCatalog#getParentNextOutline(PdfDictionary)} is called to get a hierarchical parent's next node. {@code null} is returned if one does not exist.
-     *
-     * @return the {@link PdfDictionary} object of the next outline if one exists, {@code null} otherwise.
-     */
-    private PdfDictionary getNextOutline(PdfDictionary first, PdfDictionary next, PdfDictionary parent) {
-        if (first != null) {
-            return first;
-        } else if (next != null) {
-            return next;
-        } else {
-            return getParentNextOutline(parent);
-        }
-
-    }
-
-    /**
-     * Gets the parent's next outline of the current node.
-     * If the parent does not have a next we look at the grand parent, great-grand parent, etc until we find a next node or reach the root at which point {@code null} is returned to signify there is no next node present.
-     *
-     * @return the {@link PdfDictionary} object of the next outline if one exists, {@code null} otherwise.
-     */
-    private PdfDictionary getParentNextOutline(PdfDictionary parent) {
-        if (parent == null) {
-            return null;
-        }
-        PdfDictionary current = null;
-        while (current == null) {
-            current = parent.getAsDictionary(PdfName.Next);
-            if (current == null) {
-                parent = parent.getAsDictionary(PdfName.Parent);
-                if (parent == null) {
-                    return null;
-                }
-            }
-        }
-        return current;
-    }
-
     private void addOutlineToPage(PdfOutline outline, PdfDictionary item, Map<String, PdfObject> names) {
         PdfObject dest = item.get(PdfName.Dest);
         if (dest != null) {
@@ -594,31 +554,39 @@ public class PdfCatalog extends PdfObjectWrapper<PdfDictionary> {
         if (outlineRoot == null) {
             return;
         }
-        PdfDictionary first = outlineRoot.getAsDictionary(PdfName.First);
-        PdfDictionary current = first;
-        PdfDictionary next;
-        PdfDictionary parent;
-        HashMap<PdfDictionary, PdfOutline> parentOutlineMap = new HashMap<>();
+        PdfDictionary current = outlineRoot.getAsDictionary(PdfName.First);
 
         outlines = new PdfOutline(OutlineRoot, outlineRoot, getDocument());
         PdfOutline parentOutline = outlines;
-        parentOutlineMap.put(outlineRoot, parentOutline);
+
+        // map `PdfOutline` to the next sibling to process in the hierarchy
+        HashMap<PdfOutline, PdfDictionary> positionMap = new HashMap<>();
 
         while (current != null) {
-            first = current.getAsDictionary(PdfName.First);
-            next = current.getAsDictionary(PdfName.Next);
-            parent = current.getAsDictionary(PdfName.Parent);
-
-            parentOutline = parentOutlineMap.get(parent);
             PdfOutline currentOutline = new PdfOutline(current.getAsString(PdfName.Title).toUnicodeString(), current, parentOutline);
             addOutlineToPage(currentOutline, current, names);
             parentOutline.getAllChildren().add(currentOutline);
 
+            PdfDictionary first = current.getAsDictionary(PdfName.First);
+            PdfDictionary next = current.getAsDictionary(PdfName.Next);
             if (first != null) {
-                parentOutlineMap.put(current, currentOutline);
+                // Down in hierarchy; when returning up, process `next`
+                positionMap.put(parentOutline, next);
+                parentOutline = currentOutline;
+                current = first;
+            } else if (next != null) {
+                // Next sibling in hierarchy
+                current = next;
+            } else {
+                // Up in hierarchy using `positionMap`
+                current = null;
+                while (current == null && parentOutline != null) {
+                    parentOutline = parentOutline.getParent();
+                    if (parentOutline != null) {
+                        current = positionMap.get(parentOutline);
+                    }
+                }
             }
-            current = getNextOutline(first, next, parent);
-
         }
     }
 


### PR DESCRIPTION
Some PDF processors generate empty Parent directories, rather than
including valid Parent directory links in their Outlines. Previous
PdfOutline::constructOutlines() code required correct Parent links.
This version is equivalent for correct PDFs, but ignores the Parent
links in the PDF; instead, it follows the hierarchy implied by
First links.

I have not added a minimal PDF test case. The erroneous PDF I found looks like this in itext RUPS:
![image](https://user-images.githubusercontent.com/410647/73610610-48b68e80-45a7-11ea-8f62-00512d4c9c7c.png)
Note that the “Parent” reference is to an empty dictionary, rather than, as expected, the “2 0 R” dictionary that is the true parent. Every “Parent” reference in this PDF Catalog is a different empty dictionary—none of the Parent links are correct. In the current itext7 code, processing this PDF will often cause a null pointer exception, because the previous code essentially assumed that the Parent dictionary links were correct.

The PDF had /Creator “LaTeX with hyperref” and Producer “macOS Version  10.15.2 (Build 19C57) Quartz PDFContext”.

I have run the tests.

This is my first contribution to the itext project; thanks for the project! I'm happy to answer questions and maybe do more test case work.
