### PR TITLE
Add InvalidAfmPfm to IOException.

### DIFF
--- a/io/src/main/java/com/itextpdf/io/IOException.java
+++ b/io/src/main/java/com/itextpdf/io/IOException.java
@@ -112,6 +112,7 @@ public class IOException extends RuntimeException {
     public static final String InvalidWoffFile = "Invalid WOFF font file.";
     public static final String InvalidMagicValueForBmpFileMustBeBM = "Invalid magic value for bmp file. Must be 'BM'";
     public static final String InvalidTtcFile = "{0} is not a valid TTC file.";
+    public static final String InvalidAfmPfm = "Invalid afm or pfm font file.";
     public static final String IoException = "I/O exception.";
     public static final String Jbig2ImageException = "JBIG2 image exception.";
     public static final String Jpeg2000ImageException = "JPEG2000 image exception.";

--- a/io/src/main/java/com/itextpdf/io/font/Type1Parser.java
+++ b/io/src/main/java/com/itextpdf/io/font/Type1Parser.java
@@ -129,14 +129,14 @@ class Type1Parser implements Serializable {
                 try {
                     Pfm2afm.convert(rf, ba);
                 } catch (Exception ignored) {
-                    throw new IOException("Invalid afm or pfm font file.");
+                    throw new IOException(IOException.InvalidAfmPfm);
                 } finally {
                     rf.close();
                 }
                 return new RandomAccessFileOrArray(sourceFactory.createSource(ba.toByteArray()));
             }
         } else {
-            throw new IOException("Invalid afm or pfm font file.");
+            throw new IOException(IOException.InvalidAfmPfm);
         }
     }
 

--- a/kernel/src/test/java/com/itextpdf/kernel/pdf/PdfFontTest.java
+++ b/kernel/src/test/java/com/itextpdf/kernel/pdf/PdfFontTest.java
@@ -1374,7 +1374,7 @@ public class PdfFontTest extends ExtendedITextTest {
         } catch (com.itextpdf.io.IOException e) {
             message = e.getMessage();
         }
-        Assert.assertEquals("Invalid afm or pfm font file.", message);
+        Assert.assertEquals(IOException.InvalidAfmPfm, message);
     }
 
     @Test


### PR DESCRIPTION
Add a new String constant to IOException, because it can be often used. 