### PR TITLE
Ignore invalid catalog version on document load

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfDocument.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfDocument.java
@@ -1918,9 +1918,12 @@ public class PdfDocument implements IEventDispatcher, Closeable, Serializable {
                 if (catalog.getPdfObject().containsKey(PdfName.Version)) {
                     // The version of the PDF specification to which the document conforms (for example, 1.4)
                     // if later than the version specified in the file's header
-                    PdfVersion catalogVersion = PdfVersion.fromPdfName(catalog.getPdfObject().getAsName(PdfName.Version));
-                    if (catalogVersion.compareTo(pdfVersion) > 0) {
-                        pdfVersion = catalogVersion;
+                    try {
+                        PdfVersion catalogVersion = PdfVersion.fromPdfName(catalog.getPdfObject().getAsName(PdfName.Version));
+                        if (catalogVersion.compareTo(pdfVersion) > 0) {
+                            pdfVersion = catalogVersion;
+                        }
+                    } catch (IllegalArgumentException ignored){
                     }
                 }
                 PdfStream xmpMetadataStream = catalog.getPdfObject().getAsStream(PdfName.Metadata);

--- a/kernel/src/test/java/com/itextpdf/kernel/pdf/PdfDocumentTest.java
+++ b/kernel/src/test/java/com/itextpdf/kernel/pdf/PdfDocumentTest.java
@@ -451,6 +451,14 @@ public class PdfDocumentTest extends ExtendedITextTest {
         ignoreTagStructureDocument.close();
     }
 
+    @Test
+    public void openDocumentWithInvalidCatalogVersionTest() throws IOException {
+        PdfReader reader = new PdfReader(sourceFolder + "sample-with-invalid-catalog-version.pdf");
+        PdfDocument pdfDocument = new PdfDocument(reader);
+        Assert.assertNotNull(pdfDocument);
+    }
+
+
     private static class IgnoreTagStructurePdfDocument extends PdfDocument {
 
         IgnoreTagStructurePdfDocument(PdfReader reader) {

--- a/kernel/src/test/resources/com/itextpdf/kernel/pdf/PdfDocumentTest/sample-with-invalid-catalog-version.pdf
+++ b/kernel/src/test/resources/com/itextpdf/kernel/pdf/PdfDocumentTest/sample-with-invalid-catalog-version.pdf
@@ -1,0 +1,58 @@
+%PDF-1.3
+%¿÷¢ş
+1 0 obj
+<< /Outlines 3 0 R /Pages 4 0 R /Type /Catalog /Version /PDF-1.3 >>
+endobj
+2 0 obj
+<< /CreationDate (D:20060301072826) /Creator (Rave \(http://www.nevrona.com/rave\)) /Producer (Nevrona Designs) >>
+endobj
+3 0 obj
+<< /Count 0 /Type /Outlines >>
+endobj
+4 0 obj
+<< /Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages >>
+endobj
+5 0 obj
+<< /Contents 7 0 R /MediaBox [ 0 0 612.0000 792.0000 ] /Parent 4 0 R /Resources << /Font << /F1 8 0 R >> /ProcSet 9 0 R >> /Type /Page >>
+endobj
+6 0 obj
+<< /Contents 10 0 R /MediaBox [ 0 0 612.0000 792.0000 ] /Parent 4 0 R /Resources << /Font << /F1 8 0 R >> /ProcSet 9 0 R >> /Type /Page >>
+endobj
+7 0 obj
+<< /Length 311 /Filter /FlateDecode >>
+stream
+xœ½“ÍjÃ0„ï¿Ã[h·²âù˜´É¡(Ôô.bÙQ°å`É¥ôék'$…@ƒJ¡’;}ÃÎ²Ïa°(Â€aº}«ŒñEIF³,aÈ8'.CQ†ÁæxÕí¾QxyZa¥ÇâÅ.–Å‘vdDìÀHsâÉø5‚R&NŒb«-Æ'a[Ù4(UÛëzétg@û²B5‘ï½ØiL‹Oìİ`ª®Ç`´Û*¼éŞ²ÁZm¶Òè…\×kÙXÂºëœúp„¹)ÑNÒÇ6á”%üd{ğ‘>&\ˆÏ¹ı
+ÿ“ô±Ryzµ·Å˜Ÿ©ïğ9s_SŸGùçV½sNrNyÎıröáÿ>·dÜÙhv}nrù®ÌA;ã´T‰q	÷²Và ¢oß/,„€
+endstream
+endobj
+8 0 obj
+<< /BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font >>
+endobj
+9 0 obj
+[ /PDF /Text ]
+endobj
+10 0 obj
+<< /Length 274 /Filter /FlateDecode >>
+stream
+xœ’Áj„0†ï‚ïğ[X¦1ÕÄ+­‡Bi¡^z´kÔ,E#vß¾YEØÓ"%‡ÌäûfÂp¼ù^’ùÃe•ï=¤ãYé{‘¤G1HÎ‰ÇŒ!+|ï_ºí…Ï—©vÇ=²“ï½f+melaˆ'â‘{*â˜‹7;cµ™TrèZôy¥¾•EÛ
+VıZÂ³)n¤{ÄRˆÄ&¾ÍÛ™îÑŠ$7í
+ø¨¨»?İ M{î—­Ö#F;•%!™,Lg‘Û%Í¹=Ö—x7â$#¾yû\‹b8ÿ·Õıÿ2r3²‰“¥zŞå€¶ÖË4«”)Ü¡“¦qézVMsíûmü´ö
+endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000098 00000 n 
+0000000228 00000 n 
+0000000274 00000 n 
+0000000339 00000 n 
+0000000492 00000 n 
+0000000646 00000 n 
+0000001029 00000 n 
+0000001136 00000 n 
+0000001166 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 11 /ID [<5802c47c26ce384ba878460012d8c7d1><5802c47c26ce384ba878460012d8c7d1>] >>
+startxref
+1513
+%%EOF


### PR DESCRIPTION
Some invalid values in the optional Version field of the Catalog
caused an exception on PDFDocument construction.
It is now ignored and the document is created successfully.