### PR TITLE
Add null check on producer string

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfDocument.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfDocument.java
@@ -2186,7 +2186,8 @@ public class PdfDocument implements IEventDispatcher, Closeable, Serializable {
             producer = versionInfo.getVersion();
         } else {
             if (info.getPdfObject().containsKey(PdfName.Producer)) {
-                producer = info.getPdfObject().getAsString(PdfName.Producer).toUnicodeString();
+            	PdfString producerPdfStr = info.getPdfObject().getAsString(PdfName.Producer);
+            	producer = producerPdfStr != null ? producerPdfStr.toUnicodeString() : null;
             }
             producer = addModifiedPostfix(producer);
         }


### PR DESCRIPTION
Ran into a null pointer exception at a customer site.  iText doesn't provide a mechanism to create a PDF with a null producer string, so creating a unit test that demonstrates the issue isn't real easy.  Hopefully you can see from the code that the potential for an NPE exists, and agree that the fix I'm proposing is easy, safe and worthwhile.