### PR TITLE
fix signature without LTV issue

### DIFF
--- a/sign/src/main/java/com/itextpdf/signatures/PdfSigner.java
+++ b/sign/src/main/java/com/itextpdf/signatures/PdfSigner.java
@@ -592,9 +592,30 @@ public class PdfSigner {
         }
 
         Collection<byte[]> crlBytes = null;
-        int i = 0;
-        while (crlBytes == null && i < chain.length)
-            crlBytes = processCrl(chain[i++], crlList);
+        if (crlList != null) {
+            int i = 0;
+            crlBytes = new ArrayList<>();
+            while (i < chain.length - 1) {
+                Collection<byte[]> crls = processCrl(chain[i++], crlList);
+                if (crls != null) {
+                    Collection<byte[]> tempCrls = new ArrayList<>();
+                    for (byte[] e1 : crls) {
+                        boolean check = true;
+                        for (byte[] e2 : crlBytes) {
+                            if (Arrays.equals(e1, e2)) {
+                                check = false;
+                                break;
+                            }
+                        }
+                        if (check) {
+                            tempCrls.add(e1);
+                        }
+                    }
+                    crlBytes.addAll(tempCrls);
+                }
+            }
+        }
+        
         if (estimatedSize == 0) {
             estimatedSize = 8192;
             if (crlBytes != null) {


### PR DESCRIPTION
1. fix issue when signature signed without sufficient CRL information to make LTV(Long-Term Validation) enabled
2. fix CRL lost problem when signature signed with "crlList.add(new CrlClientOnline())"
3. ignores repeated CRL when  signature signed with "crlList.add(new CrlClientOnline(chain))" or "crlList.add(new CrlClientOnline(crl1, crl2, ...))"