### PR TITLE
Patch for dealing with badly formed pdfs made on an ipad

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfReader.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/pdf/PdfReader.java
@@ -923,7 +923,8 @@ public class PdfReader implements Closeable, Serializable {
             tokens.nextValidToken();
             if (tokens.getTokenType() == PdfTokenizer.TokenType.EndDic)
                 break;
-            if (tokens.getTokenType() != PdfTokenizer.TokenType.Name)
+            //following needed for a pdf created with ipad where the dictionary started with a String not a name
+            if (tokens.getTokenType() != PdfTokenizer.TokenType.Name && tokens.getTokenType()!=PdfTokenizer.TokenType.String)
                 tokens.throwError(PdfException.DictionaryKey1IsNotAName, tokens.getStringValue());
             PdfName name = readPdfName(true);
             PdfObject obj = readObject(true, objStm);


### PR DESCRIPTION
While reading a pdf annotated on an iPad, the dictionary was created with a String "Name" and not a token.Name.  If we accept a String as a valid name, the reader can continue.

Makes me think that there should be a way of continuing if an err occurs.