### PR TITLE
Set PubKeySecurityHandler output stream with DER encoding format

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/crypto/securityhandler/PubKeySecurityHandler.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/crypto/securityhandler/PubKeySecurityHandler.java
@@ -51,6 +51,7 @@ import com.itextpdf.kernel.pdf.PdfDictionary;
 import com.itextpdf.kernel.pdf.PdfLiteral;
 import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.security.IExternalDecryptionProcess;
+import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -250,7 +251,7 @@ public abstract class PubKeySecurityHandler extends SecurityHandler {
         pkcs7input[23] = one;
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ASN1OutputStream k = ASN1OutputStream.create(baos);
+        ASN1OutputStream k = ASN1OutputStream.create(baos, ASN1Encoding.DER);
         ASN1Primitive obj = createDERForRecipient(pkcs7input, (X509Certificate) certificate);
         k.writeObject(obj);
         cms = baos.toByteArray();


### PR DESCRIPTION
Hi there,

I found an incompatible behavior in `PubKeySecurityHandler`.

We upgrade `bouncycastle` in [7.1.14](https://github.com/itext/itext7/commit/400b2f9b475009b229df99f7c00d3f8b35886fb3), and change the `DEROutputStream` to `ASN1OutputStream`, but as the documentation described, the encoding should be specified as `ASN1Encoding.DER`.

- https://javadoc.io/static/org.bouncycastle/bcprov-jdk15on/1.64/org/bouncycastle/asn1/DEROutputStream.html

Without this encoding parameter the PDF cannot be opened by Adobe Acrobat.

Here is the pdf generated by test case.

- [encryptWithCertificateAes128-DER.pdf](https://github.com/itext/itext7/files/7593831/encryptWithCertificateAes128-DER.pdf)
- [encryptWithCertificateAes128.pdf](https://github.com/itext/itext7/files/7593832/encryptWithCertificateAes128.pdf)

Thanks for reviewing.