### PR TITLE
timezone is not supported in digital signs

### DIFF
--- a/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
+++ b/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
@@ -270,7 +270,9 @@ final class SignUtils {
     }
 
     public static String dateToString(Calendar signDate) {
-        return new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z").format(signDate.getTime());
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z");
+        if(signDate.getTimeZone() != null) sdf.setTimeZone(signDate.getTimeZone());
+        return sdf.format(signDate.getTime());
     }
 
     static class TsaResponse {


### PR DESCRIPTION
when the certificate is added, there is an option to add signed by, reason, location and the signed date. timezone is not supported currently in the signed date. this change is to fix that.