### PR TITLE
fix possible ArithmeticException

### DIFF
--- a/kernel/src/main/java/com/itextpdf/kernel/crypto/ARCFOUREncryption.java
+++ b/kernel/src/main/java/com/itextpdf/kernel/crypto/ARCFOUREncryption.java
@@ -62,20 +62,22 @@ public class ARCFOUREncryption {
     }
 
     public void prepareARCFOURKey(byte[] key, int off, int len) {
-        int index1 = 0;
-        int index2 = 0;
-        for (int k = 0; k < 256; ++k) {
-            state[k] = (byte) k;
-        }
-        x = 0;
-        y = 0;
-        byte tmp;
-        for (int k = 0; k < 256; ++k) {
-            index2 = (key[index1 + off] + state[k] + index2) & 255;
-            tmp = state[k];
-            state[k] = state[index2];
-            state[index2] = tmp;
-            index1 = (index1 + 1) % len;
+        if (len != 0) {
+            int index1 = 0;
+            int index2 = 0;
+            for (int k = 0; k < 256; ++k) {
+                state[k] = (byte) k;
+            }
+            x = 0;
+            y = 0;
+            byte tmp;
+            for (int k = 0; k < 256; ++k) {
+                index2 = (key[index1 + off] + state[k] + index2) & 255;
+                tmp = state[k];
+                state[k] = state[index2];
+                state[index2] = tmp;
+                index1 = (index1 + 1) % len;
+            }
         }
     }
 


### PR DESCRIPTION
in method com.itextpdf.text.pdf.crypto.ARCFOUREncryption.prepareARCFOURKey
<img width="639" alt="image" src="https://user-images.githubusercontent.com/44200574/174020104-c484d384-84e0-43c8-8248-23c7e12f9ccc.png">
The parameter len is used as a divisor, but it is not checked in advance whether it is zero, and it is likely to trigger ArithmeticException