### PR TITLE
Bump maven-bundle-plugin to 5.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>5.1.6</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
This avoids build issues on recent JDKs, see bndtools/bnd#3903.


See also this more or less equivalent commit in RUPS from a couple months ago: https://github.com/itext/i7j-rups/commit/9a261edf5a3167b3ce34820dd3fbc486ddb172de.