### PR TITLE
Fix bug/issue when subtype is null on annotations

### DIFF
--- a/forms/src/main/java/com/itextpdf/forms/PdfPageFormCopier.java
+++ b/forms/src/main/java/com/itextpdf/forms/PdfPageFormCopier.java
@@ -113,6 +113,10 @@ public class PdfPageFormCopier implements IPdfPageExtraCopier {
         List<PdfAnnotation> annots = toPage.getAnnotations();
 
         for (PdfAnnotation annot : annots) {
+            if (annot.getSubtype() == null) {
+                continue;
+            }
+   
             if (!annot.getSubtype().equals(PdfName.Widget)) {
                 continue;
             }


### PR DESCRIPTION
There are some PDF files where the getSubtype function returns null, which doesn't implement equals() and that leads to an error on line 120. 

Prevent errors when the returned value on getSubtype is null, since on line 120 is going to try to call equals on the returned null.

This is a real bug/issue since in the company where I work IText is failing us because of that with some PDFs.