### PR TITLE
Use safe XML parser for rich text in PdfUA2AnnotationChecker

### DIFF
--- a/pdfua/src/main/java/com/itextpdf/pdfua/checkers/utils/ua2/PdfUA2AnnotationChecker.java
+++ b/pdfua/src/main/java/com/itextpdf/pdfua/checkers/utils/ua2/PdfUA2AnnotationChecker.java
@@ -24,7 +24,6 @@ package com.itextpdf.pdfua.checkers.utils.ua2;
 
 import com.itextpdf.commons.utils.MessageFormatUtil;
 import com.itextpdf.forms.fields.PdfFormField;
-import com.itextpdf.io.util.XmlUtil;
 import com.itextpdf.kernel.exceptions.PdfException;
 import com.itextpdf.kernel.pdf.PdfDictionary;
 import com.itextpdf.kernel.pdf.PdfDocument;
@@ -37,6 +36,7 @@ import com.itextpdf.kernel.pdf.annot.PdfAnnotation;
 import com.itextpdf.kernel.pdf.tagging.IStructureNode;
 import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import com.itextpdf.kernel.utils.XmlProcessorCreator;
 import com.itextpdf.kernel.utils.checkers.PdfCheckersUtil;
 import com.itextpdf.pdfua.checkers.utils.ContextAwareTagTreeIteratorHandler;
 import com.itextpdf.pdfua.checkers.utils.PdfUAValidationContext;
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.xml.parsers.DocumentBuilder;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -164,7 +165,8 @@ public class PdfUA2AnnotationChecker {
             return richText;
         }
         try {
-            return parseRichText(XmlUtil.initXmlDocument(new ByteArrayInputStream(
+            DocumentBuilder db = XmlProcessorCreator.createSafeDocumentBuilder(false, false);
+            return parseRichText(db.parse(new ByteArrayInputStream(
                     richText.getBytes(StandardCharsets.UTF_8))));
         } catch (Exception e) {
             throw new PdfException(e.getMessage(), e);

--- a/pdfua/src/test/java/com/itextpdf/pdfua/checkers/utils/ua2/PdfUA2AnnotationCheckerUnitTest.java
+++ b/pdfua/src/test/java/com/itextpdf/pdfua/checkers/utils/ua2/PdfUA2AnnotationCheckerUnitTest.java
@@ -24,11 +24,13 @@ package com.itextpdf.pdfua.checkers.utils.ua2;
 
 import com.itextpdf.commons.utils.MessageFormatUtil;
 import com.itextpdf.io.source.ByteArrayOutputStream;
+import com.itextpdf.kernel.exceptions.PdfException;
 import com.itextpdf.kernel.geom.Rectangle;
 import com.itextpdf.kernel.pdf.PdfArray;
 import com.itextpdf.kernel.pdf.PdfDictionary;
 import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.PdfPage;
+import com.itextpdf.kernel.pdf.PdfString;
 import com.itextpdf.kernel.pdf.PdfUAConformance;
 import com.itextpdf.kernel.pdf.PdfVersion;
 import com.itextpdf.kernel.pdf.PdfWriter;
@@ -47,18 +49,37 @@ import com.itextpdf.kernel.pdf.filespec.PdfFileSpec;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import com.itextpdf.kernel.pdf.tagging.StandardRoles;
 import com.itextpdf.kernel.pdf.tagutils.TagTreePointer;
+import com.itextpdf.kernel.utils.XmlProcessorCreator;
 import com.itextpdf.pdfua.PdfUAConfig;
 import com.itextpdf.pdfua.PdfUADocument;
 import com.itextpdf.pdfua.exceptions.PdfUAConformanceException;
 import com.itextpdf.pdfua.exceptions.PdfUAExceptionMessageConstants;
+import com.itextpdf.test.ExceptionTestUtil;
 import com.itextpdf.test.ExtendedITextTest;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("UnitTest")
 public class PdfUA2AnnotationCheckerUnitTest extends ExtendedITextTest {
+
+    private static final String RICH_TEXT_WITH_XXE = "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE r [ <!ENTITY xxe SYSTEM \"xxe-data.txt\"> ]>\n"
+            + "<body xmlns=\"http://www.w3.org/1999/xhtml\"><p>&xxe;</p></body>";
+
+    @BeforeEach
+    public void resetXmlParserFactoryToDefault() {
+        XmlProcessorCreator.setXmlParserFactory(null);
+    }
+
+    @Test
+    public void richTextWithXxeIsRejected() {
+        Exception e = Assertions.assertThrows(PdfException.class,
+                () -> PdfUA2AnnotationChecker.getRichTextStringValue(new PdfString(RICH_TEXT_WITH_XXE)));
+        Assertions.assertEquals(ExceptionTestUtil.getDoctypeIsDisallowedExceptionMessage(), e.getMessage());
+    }
 
     @Test
     public void basicAnnotationBadParent() {


### PR DESCRIPTION
1. getRichTextStringValue parses the RC (rich text) entry of an annotation, which comes straight from the PDF being validated for PDF/UA-2 conformance.
2. it used XmlUtil.initXmlDocument, a bare DocumentBuilderFactory.newInstance() with DOCTYPE and external entities left enabled, so a crafted RC stream can pull in an external entity (local file read / SSRF).
3. switched the parse to XmlProcessorCreator.createSafeDocumentBuilder, the same hardened factory used elsewhere in the library, which rejects DOCTYPE and external entities.

Validation: added a unit test feeding an RC value with a DOCTYPE/external entity; it fails on the old parser and passes once the safe builder rejects the declaration.