### PR TITLE
Escape value in CSS ~= attribute selector matching

### DIFF
--- a/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssAttributeSelectorItem.java
+++ b/styled-xml-parser/src/main/java/com/itextpdf/styledxmlparser/css/selector/item/CssAttributeSelectorItem.java
@@ -103,7 +103,9 @@ public class CssAttributeSelectorItem implements ICssSelectorItem {
                 case '$':
                     return value.length() > 0 && attributeValue.endsWith(value);
                 case '~':
-                    String pattern = MessageFormatUtil.format("(^{0}\\s+)|(\\s+{1}\\s+)|(\\s+{2}$)", value, value, value);
+                    String quotedValue = Pattern.quote(value);
+                    String pattern = MessageFormatUtil.format("(^{0}\\s+)|(\\s+{1}\\s+)|(\\s+{2}$)", quotedValue,
+                            quotedValue, quotedValue);
                     return Pattern.compile(pattern).matcher(attributeValue).matches();
                 case '*':
                     return value.length() > 0 && attributeValue.contains(value);

--- a/styled-xml-parser/src/test/java/com/itextpdf/styledxmlparser/css/selector/item/CssMatchesTest.java
+++ b/styled-xml-parser/src/test/java/com/itextpdf/styledxmlparser/css/selector/item/CssMatchesTest.java
@@ -431,6 +431,48 @@ public class CssMatchesTest extends ExtendedITextTest {
     }
 
     @Test
+    public void matchesAttributeContainsWordTreatsValueAsLiteralTest() {
+        CssAttributeSelectorItem item = new CssAttributeSelectorItem("[data-info~=\"a.c\"]");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<div data-info=\" abc\"></div>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode divNode = bodyNode.childNodes().get(0);
+
+        Assertions.assertFalse(item.matches(divNode));
+    }
+
+    @Test
+    public void matchesAttributeContainsWordLiteralValueTest() {
+        CssAttributeSelectorItem item = new CssAttributeSelectorItem("[data-info~=\"abc\"]");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<div data-info=\" abc\"></div>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode divNode = bodyNode.childNodes().get(0);
+
+        Assertions.assertTrue(item.matches(divNode));
+    }
+
+    @Test
+    public void matchesAttributeContainsWordInvalidRegexValueTest() {
+        CssAttributeSelectorItem item = new CssAttributeSelectorItem("[data-info~=\"(\"]");
+        IXmlParser htmlParser = new JsoupHtmlParser();
+        IDocumentNode documentNode = htmlParser.parse("<div data-info=\" abc\"></div>");
+
+        INode bodyNode = documentNode
+                .childNodes().get(0)
+                .childNodes().get(1);
+        INode divNode = bodyNode.childNodes().get(0);
+
+        Assertions.assertFalse(item.matches(divNode));
+    }
+
+    @Test
     public void cssPageTypeSelectorItemMatchesTest() {
         CssPageTypeSelectorItem item = new CssPageTypeSelectorItem("customPageName");
 


### PR DESCRIPTION
1. The `~=` attribute selector in `CssAttributeSelectorItem` builds a regex from the selector value, so the value is treated as a pattern instead of a literal word.
2. The value comes from untrusted CSS in an SVG/HTML document, so metacharacters change matching (for example `a.c` matches `abc`) and an unbalanced group such as `(` throws an unchecked PatternSyntaxException during style resolution.
3. Quoted the value with Pattern.quote before building the pattern, so it matches literally per the CSS `~=` semantics.